### PR TITLE
chore: Use CARGO_TARGET_DIR for insta to avoid rebuild

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -7,8 +7,8 @@ platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
 [tasks]
 build = "cargo build"
 build-release = "cargo build --release"
-test = "CARGO_TARGET_DIR=target/insta cargo insta test --review"
-test-all = "CARGO_TARGET_DIR=target/insta cargo insta test --review --all-features"
+test = { cmd = "cargo insta test --review", env = { CARGO_TARGET_DIR = "target/insta" } }
+test-all = { cmd = "cargo insta test --review --all-features", env = { CARGO_TARGET_DIR = "target/insta" } }
 
 [dependencies]
 actionlint = ">=1.7.8,<2"

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,8 +7,8 @@ platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
 [tasks]
 build = "cargo build"
 build-release = "cargo build --release"
-test = "cargo insta test --review"
-test-all = "cargo insta test --review --all-features"
+test = "CARGO_TARGET_DIR=target/insta cargo insta test --review"
+test-all = "CARGO_TARGET_DIR=target/insta cargo insta test --review --all-features"
 
 [dependencies]
 actionlint = ">=1.7.8,<2"


### PR DESCRIPTION
`cargo insta` looks to be using conflicting build settings with `cargo build`. This causes unnecessary rebuild if we run them alternatively. To avoid this, this patch ensures using `CARGO_TARGET_DIR` for insta.

---

This is a common technique https://github.com/kenoss/sabiniwm/blob/main/justfile#L5.