### PR TITLE
feat: Improve error for install with specific version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ futures-util = "0.3.31"
 indicatif = "0.18.4"
 miette = { version = "7.6.0", features = ["fancy"] }
 rattler_digest = "1.1.7"
+regex = "1.12.2"
 remove_dir_all = "1.0.0"
 reqwest = { version = "0.13.4", features = ["json", "stream"] }
 reqwest-middleware = "0.5.2"
@@ -64,7 +65,6 @@ temp-env = "0.3.6"
 # see: https://github.com/zhiburt/expectrl/issues/52
 [target.'cfg(not(windows))'.dev-dependencies]
 expectrl = "0.9.0"
-regex = "1.12.2"
 
 [features]
 default = ["self_update"]

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -103,10 +103,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         },
     };
 
-    let recipe = build_installrecipe(&spec).await?.unwrap_or_else(|| {
-        eprintln!("No toolchain available for requested spec '{}'", spec);
-        std::process::exit(1);
-    });
+    let recipe = build_installrecipe(&spec).await?;
 
     println!("Installing toolchain '{}'", spec);
     populate_install(&recipe).await?;

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -32,9 +32,7 @@ async fn update_toolchain(path: &mut PathBuf, spec: &ToolchainSpec) -> miette::R
         }
         Err(e) => Err(miette::miette!(e).wrap_err("failed to read version file")),
         Ok(local_ver) => {
-            let recipe = build_installrecipe(spec)
-                .await?
-                .expect("should have recipe");
+            let recipe = build_installrecipe(spec).await?;
 
             let should_update = match (spec, local_ver.trim()) {
                 (ToolchainSpec::Bleeding, _) => true,

--- a/src/toolchain/index.rs
+++ b/src/toolchain/index.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Duration, Local};
-use miette::{Context, IntoDiagnostic};
+use miette::{Context, IntoDiagnostic, MietteDiagnostic};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::constant;
@@ -402,22 +402,24 @@ pub async fn build_installrecipe(spec: &ToolchainSpec) -> miette::Result<Install
                         };
                         let prev = if i == 0 { None } else { versions.get(i - 1) };
                         let next = versions.get(i);
-                        let hint = match (prev, next) {
-                            (None, None) => "".to_string(),
-                            (None, Some(next)) => {
-                                format!("\n\nHint: {} is available.", next.original)
-                            }
-                            (Some(prev), None) => {
-                                format!("\n\nHint: {} is available.", prev.original)
-                            }
-                            (Some(prev), Some(next)) => format!(
-                                "\n\nHint: {} and {} are available.",
+                        let help = match (prev, next) {
+                            (None, None) => None,
+                            (None, Some(next)) => Some(format!("{} is available.", next.original)),
+                            (Some(prev), None) => Some(format!("{} is available.", prev.original)),
+                            (Some(prev), Some(next)) => Some(format!(
+                                "{} and {} are available.",
                                 prev.original, next.original
-                            ),
+                            )),
                         };
-                        return Err(miette::miette!(
-                            "No release available for requested spec: {s}.{hint}"
+                        let diag = MietteDiagnostic::new(format!(
+                            "No release available for requested spec: {s}."
                         ));
+                        let diag = if let Some(help) = help {
+                            diag.with_help(help)
+                        } else {
+                            diag
+                        };
+                        return Err(diag.into());
                     }
                 }
             }

--- a/src/toolchain/index.rs
+++ b/src/toolchain/index.rs
@@ -277,7 +277,7 @@ pub async fn build_installrecipe(spec: &ToolchainSpec) -> miette::Result<Install
                 Some(x) => x,
                 None => {
                     return Err(miette::miette!(
-                        "no release available for requested spec: {}",
+                        "No release available for requested spec: {}",
                         spec
                     ));
                 }
@@ -311,7 +311,7 @@ pub async fn build_installrecipe(spec: &ToolchainSpec) -> miette::Result<Install
                 None => {
                     if is_nightly {
                         return Err(miette::miette!(
-                            "no release available for requested spec: {}",
+                            "No release available for requested spec: {}",
                             spec
                         ));
                     } else {
@@ -405,18 +405,18 @@ pub async fn build_installrecipe(spec: &ToolchainSpec) -> miette::Result<Install
                         let hint = match (prev, next) {
                             (None, None) => "".to_string(),
                             (None, Some(next)) => {
-                                format!(" hint: e.g. {} is available.", next.original)
+                                format!("\n\nHint: {} is available.", next.original)
                             }
                             (Some(prev), None) => {
-                                format!(" hint: e.g. {} is available.", prev.original)
+                                format!("\n\nHint: {} is available.", prev.original)
                             }
                             (Some(prev), Some(next)) => format!(
-                                " hint: e.g. {} and {} are available.",
+                                "\n\nHint: {} and {} are available.",
                                 prev.original, next.original
                             ),
                         };
                         return Err(miette::miette!(
-                            "no release available for requested spec: {s}.{hint}"
+                            "No release available for requested spec: {s}.{hint}"
                         ));
                     }
                 }

--- a/src/toolchain/index.rs
+++ b/src/toolchain/index.rs
@@ -266,14 +266,22 @@ async fn read_json_with_lock(path: &Path) -> miette::Result<(bool, String)> {
     }
 }
 
-pub async fn build_installrecipe(spec: &ToolchainSpec) -> miette::Result<Option<InstallRecipe>> {
+pub async fn build_installrecipe(spec: &ToolchainSpec) -> miette::Result<InstallRecipe> {
     let channel = ChannelName::from(spec);
     let index = read_channel_index(&channel).await?;
     let mut releases = index.releases().iter().filter(|r| r.is_host_supported());
 
     let release = match spec {
         ToolchainSpec::Bleeding | ToolchainSpec::Latest | ToolchainSpec::Nightly => {
-            releases.next_back().cloned().or(None)
+            match releases.next_back().cloned() {
+                Some(x) => x,
+                None => {
+                    return Err(miette::miette!(
+                        "no release available for requested spec: {}",
+                        spec
+                    ));
+                }
+            }
         }
         ToolchainSpec::Version(s) => {
             let is_nightly = s.starts_with("nightly");
@@ -284,28 +292,135 @@ pub async fn build_installrecipe(spec: &ToolchainSpec) -> miette::Result<Option<
                 s
             };
 
-            releases
-                .find(|&release| {
-                    if is_nightly {
-                        release
-                            .date
-                            .as_deref()
-                            .map(|d| d == req_version)
-                            .unwrap_or(false)
-                    } else {
-                        release.version.as_str() == req_version
-                    }
-                })
-                .cloned()
-                .or(None)
-        }
-    };
+            let releases = releases.collect::<Vec<_>>();
 
-    let release = match release {
-        Some(r) => r,
-        None => {
-            tracing::debug!("no release available for requested spec: {}", spec);
-            return Ok(None);
+            let x = releases.iter().find(|release| {
+                if is_nightly {
+                    release
+                        .date
+                        .as_deref()
+                        .map(|d| d == req_version)
+                        .unwrap_or(false)
+                } else {
+                    release.version.as_str() == req_version
+                }
+            });
+
+            match x {
+                Some(&x) => x.clone(),
+                None => {
+                    if is_nightly {
+                        return Err(miette::miette!(
+                            "no release available for requested spec: {}",
+                            spec
+                        ));
+                    } else {
+                        // Return an error with hint.
+
+                        use regex::Regex;
+                        use std::sync::LazyLock;
+
+                        #[derive(Debug, Clone, PartialEq, Eq)]
+                        struct ParsedVersion {
+                            original: String,
+                            major: Option<usize>,
+                            minor: Option<usize>,
+                            patch: Option<usize>,
+                            hash: Option<String>,
+                        }
+
+                        impl ParsedVersion {
+                            fn parse(version: &str) -> Self {
+                                static RE: LazyLock<Regex> = LazyLock::new(|| {
+                                    Regex::new(
+                                        r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:\+(?P<hash>[A-Za-z0-9]+))?$",
+                                    )
+                                        .unwrap()
+                                });
+
+                                let mut parsed = Self {
+                                    original: version.to_string(),
+                                    major: None,
+                                    minor: None,
+                                    patch: None,
+                                    hash: None,
+                                };
+
+                                if let Some(caps) = RE.captures(version) {
+                                    parsed.major =
+                                        caps.name("major").and_then(|m| m.as_str().parse().ok());
+
+                                    parsed.minor =
+                                        caps.name("minor").and_then(|m| m.as_str().parse().ok());
+
+                                    parsed.patch =
+                                        caps.name("patch").and_then(|m| m.as_str().parse().ok());
+
+                                    parsed.hash = caps.name("hash").map(|m| m.as_str().to_string());
+                                }
+
+                                parsed
+                            }
+                        }
+
+                        impl PartialOrd for ParsedVersion {
+                            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+                                Some(self.cmp(other))
+                            }
+                        }
+
+                        impl Ord for ParsedVersion {
+                            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+                                fn f(x: &Option<usize>) -> isize {
+                                    x.map(|x| x.try_into().unwrap(/* assume version is not so huge */)).unwrap_or(-1)
+                                }
+
+                                f(&self.major)
+                                    .cmp(&f(&other.major))
+                                    .then(f(&self.minor).cmp(&f(&other.minor)))
+                                    .then(f(&self.minor).cmp(&f(&other.minor)))
+                                    .then(f(&self.patch).cmp(&f(&other.patch)))
+                                    .then(
+                                        self.hash
+                                            .as_deref()
+                                            .unwrap_or("")
+                                            .cmp(other.hash.as_deref().unwrap_or("")),
+                                    )
+                                    .then(self.original.cmp(&other.original))
+                            }
+                        }
+
+                        let mut versions = releases
+                            .into_iter()
+                            .map(|release| ParsedVersion::parse(&release.version))
+                            .collect::<Vec<_>>();
+                        versions.sort();
+                        let version = ParsedVersion::parse(s);
+                        let Err(i) = versions.binary_search(&version) else {
+                            // Checked avobe.
+                            unreachable!();
+                        };
+                        let prev = if i == 0 { None } else { versions.get(i - 1) };
+                        let next = versions.get(i);
+                        let hint = match (prev, next) {
+                            (None, None) => "".to_string(),
+                            (None, Some(next)) => {
+                                format!(" hint: e.g. {} is available.", next.original)
+                            }
+                            (Some(prev), None) => {
+                                format!(" hint: e.g. {} is available.", prev.original)
+                            }
+                            (Some(prev), Some(next)) => format!(
+                                " hint: e.g. {} and {} are available.",
+                                prev.original, next.original
+                            ),
+                        };
+                        return Err(miette::miette!(
+                            "no release available for requested spec: {s}.{hint}"
+                        ));
+                    }
+                }
+            }
         }
     };
 
@@ -319,5 +434,5 @@ pub async fn build_installrecipe(spec: &ToolchainSpec) -> miette::Result<Option<
         components,
     };
 
-    Ok(Some(recipe))
+    Ok(recipe)
 }

--- a/tests/e2e/flow.rs
+++ b/tests/e2e/flow.rs
@@ -88,6 +88,13 @@ fn test_flow_with_network_mock() {
             .arg("--list-available")
             .arg("-vvv")
     );
+    assert_cmd_snapshot!(
+        "moonup_install_specific_version_unavailable_mock",
+        ws.cli()
+            .env(constant::ENVNAME_MOONUP_DIST_SERVER, s.url())
+            .arg("install")
+            .arg("0.1")
+    );
 }
 
 /// Test flow with production networking

--- a/tests/e2e/snapshots/test__e2e__flow__moonup_install_specific_version_unavailable_mock.snap
+++ b/tests/e2e/snapshots/test__e2e__flow__moonup_install_specific_version_unavailable_mock.snap
@@ -6,9 +6,9 @@ info:
     - install
     - "0.1"
   env:
-    MOONUP_DIST_SERVER: "http://127.0.0.1:37743"
-    MOONUP_HOME: /tmp/.tmpG3urbY/.moonup
-    MOON_HOME: /tmp/.tmpG3urbY/.moon
+    MOONUP_DIST_SERVER: "http://127.0.0.1:38481"
+    MOONUP_HOME: /tmp/.tmpXPj4yo/.moonup
+    MOON_HOME: /tmp/.tmpXPj4yo/.moon
 ---
 success: false
 exit_code: 1
@@ -16,5 +16,4 @@ exit_code: 1
 
 ----- stderr -----
   × No release available for requested spec: 0.1.
-  │ 
-  │ Hint: 0.1.20240704+647946c28 is available.
+  help: 0.1.20240704+647946c28 is available.

--- a/tests/e2e/snapshots/test__e2e__flow__moonup_install_specific_version_unavailable_mock.snap
+++ b/tests/e2e/snapshots/test__e2e__flow__moonup_install_specific_version_unavailable_mock.snap
@@ -6,14 +6,15 @@ info:
     - install
     - "0.1"
   env:
-    MOONUP_DIST_SERVER: "http://127.0.0.1:36523"
-    MOONUP_HOME: /tmp/.tmpCYzMof/.moonup
-    MOON_HOME: /tmp/.tmpCYzMof/.moon
+    MOONUP_DIST_SERVER: "http://127.0.0.1:37743"
+    MOONUP_HOME: /tmp/.tmpG3urbY/.moonup
+    MOON_HOME: /tmp/.tmpG3urbY/.moon
 ---
 success: false
 exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-  × no release available for requested spec: 0.1. hint: e.g.
-  │ 0.1.20240704+647946c28 is available.
+  × No release available for requested spec: 0.1.
+  │ 
+  │ Hint: 0.1.20240704+647946c28 is available.

--- a/tests/e2e/snapshots/test__e2e__flow__moonup_install_specific_version_unavailable_mock.snap
+++ b/tests/e2e/snapshots/test__e2e__flow__moonup_install_specific_version_unavailable_mock.snap
@@ -1,0 +1,19 @@
+---
+source: tests/e2e/flow.rs
+info:
+  program: moonup
+  args:
+    - install
+    - "0.1"
+  env:
+    MOONUP_DIST_SERVER: "http://127.0.0.1:36523"
+    MOONUP_HOME: /tmp/.tmpCYzMof/.moonup
+    MOON_HOME: /tmp/.tmpCYzMof/.moon
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+  × no release available for requested spec: 0.1. hint: e.g.
+  │ 0.1.20240704+647946c28 is available.


### PR DESCRIPTION
Option 1 of #189

---

Before this patch, `moonup install <specific-version>` fails with an simple error:

```
$ moonup install 0.9.3
No toolchain available for requested spec '0.9.3'
```

This patch improves the error, showing available versions near to the given version:

```
$ moonup install 0.9.3
  x no release available for requested spec: 0.9.3. hint: e.g. 0.9.3+08f337e2c is available.
```

---

Note that I'm using aarch64 Linux and I need tweaks to run tests. I checked that the test passes in my environment, but it might fail.