### PR TITLE
test: stabilize emoji use in tests on linux

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -7,8 +7,8 @@ platforms = ["linux-64", "linux-aarch64", "win-64", "osx-64", "osx-arm64"]
 [tasks]
 build = "cargo build"
 build-release = "cargo build --release"
-test = { cmd = "cargo insta test --review", env = { CARGO_TARGET_DIR = "target/insta" } }
-test-all = { cmd = "cargo insta test --review --all-features", env = { CARGO_TARGET_DIR = "target/insta" } }
+test = { cmd = "cargo insta test --review", env = { LANG = "en_US.UTF-8", CARGO_TARGET_DIR = "target/insta" } }
+test-all = { cmd = "cargo insta test --review --all-features", env = { LANG = "en_US.UTF-8", CARGO_TARGET_DIR = "target/insta" } }
 
 [dependencies]
 actionlint = ">=1.7.8,<2"

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,8 +7,8 @@ platforms = ["linux-64", "linux-aarch64", "win-64", "osx-64", "osx-arm64"]
 [tasks]
 build = "cargo build"
 build-release = "cargo build --release"
-test = { cmd = "cargo insta test --review", env = { LANG = "en_US.UTF-8", CARGO_TARGET_DIR = "target/insta" } }
-test-all = { cmd = "cargo insta test --review --all-features", env = { LANG = "en_US.UTF-8", CARGO_TARGET_DIR = "target/insta" } }
+test = { cmd = "cargo insta test --review", env = { CARGO_TARGET_DIR = "target/insta" } }
+test-all = { cmd = "cargo insta test --review --all-features", env = { CARGO_TARGET_DIR = "target/insta" } }
 
 [dependencies]
 actionlint = ">=1.7.8,<2"

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -57,6 +57,15 @@ impl TestWorkspace {
             cli.env("WT_SESSION", "1");
         }
 
+        // Force emoji support on non-macOS Unix during tests by setting LANG,
+        // as the `console` crate checks `LANG` to decide whether to use emoji.
+        // see:
+        //   https://github.com/console-rs/console/blob/0.16.3/src/unix_term.rs#L389-L396
+        #[cfg(all(unix, not(target_os = "macos")))]
+        {
+            cli.env("LANG", "en_US.UTF-8");
+        }
+
         cli.current_dir(self.project_path.as_path());
         cli
     }


### PR DESCRIPTION
~Depends on #188~ (merged)

---

Before this patch, some test results were unstable:

```
    4       │-✔ Default toolchain set to version 'latest'
          4 │+Default toolchain set to version 'latest'
```

This is because `console` crate uses `LANG` for check that we should use
emoji or not.
https://github.com/console-rs/console/blob/0.16.3/src/unix_term.rs#L389-L396

To stabilize the results, this patch adds the environment variable
`LANG` for tests.
