### PR TITLE
feat!: add partial version selector resolution

### DIFF
--- a/.agents/adr/0003-incomplete-stable-version-selectors.md
+++ b/.agents/adr/0003-incomplete-stable-version-selectors.md
@@ -1,0 +1,45 @@
+# Install incomplete stable-version selectors as concrete releases
+
+`moonup install` accepts an incomplete numeric stable-version selector such as
+`0` or `0.10`, and resolves it to a concrete release from the stable channel
+index. A three-part selector such as `0.10.1` first prefers an exact
+unqualified release; if none exists, it selects the newest matching
+build-qualified release such as `0.10.1+abcdef123`. Full build-qualified
+versions remain exact.
+
+Resolution considers only releases supported by the current host. The stable
+channel index is authoritative and is ordered oldest-first, so the newest
+matching release is the last matching entry. Existing index-cache behavior is
+unchanged.
+
+The original selector is retained as recipe metadata for diagnostics, while
+the resolved concrete version becomes the effective toolchain identity and
+installation directory. A partial selector therefore never creates a
+non-reproducible selector-named directory.
+
+## Considered Options
+
+- **Install under the selector name** — rejected: the selector can resolve to a
+  different release as the index changes, and selector-named directories would
+  duplicate concrete installations.
+- **Sort releases independently** — rejected: the distribution index defines
+  release order, including the otherwise unordered build metadata suffix.
+- **Support general semver ranges or nightly prefixes** — deferred: phase 1 is
+  intentionally limited to numeric stable selectors and install-time
+  resolution.
+- **Resolve partial selectors in every command** — deferred: the semantics of
+  pinning, default selection, running, updating, and aliases require a separate
+  design.
+
+## Consequences
+
+- `install 0`, `install 0.10`, and `install 0.10.1` can select the newest
+  compatible stable release without requiring a build hash.
+- Installing a selector and then its concrete result converges on one
+  installation directory.
+- The selected concrete version should be logged at INFO level when it differs
+  from the requested selector.
+- Phase 1 does not persist the selector or make partial selectors meaningful to
+  `pin`, `default`, `run`, shim lookup, `update`, or `list`.
+- The resolver should be a pure, independently tested seam over parsed stable
+  releases and host support.

--- a/.agents/handoff/issue-189-incomplete-version-selector.md
+++ b/.agents/handoff/issue-189-incomplete-version-selector.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Design confirmed. Implementation is the next task.
+Implemented and verified. The incomplete stable-version selector flow is complete.
 
 ## Agreed contract
 

--- a/.agents/handoff/issue-189-incomplete-version-selector.md
+++ b/.agents/handoff/issue-189-incomplete-version-selector.md
@@ -1,0 +1,44 @@
+# Handoff: Incomplete stable-version selectors (issue #189)
+
+## Status
+
+Design confirmed. Implementation is the next task.
+
+## Agreed contract
+
+- Phase 1 changes `moonup install` only.
+- Accepted incomplete forms are numeric prefixes with one, two, or three
+  dot-separated components: `0`, `0.10`, `0.10.1`.
+- No optional `v` prefix, prerelease syntax, general semver ranges, or nightly
+  partial selectors.
+- Full build-qualified versions remain exact.
+- Three-part unqualified versions prefer an exact unqualified release; if none
+  exists, they fall back to the newest matching `version+build` release.
+- One- and two-part selectors choose the last matching release.
+- Releases are filtered for host support before matching; the stable index is
+  oldest-first and authoritative.
+- `InstallRecipe` retains the requested selector as metadata and uses the
+  concrete resolved version as its effective `spec` and filesystem identity.
+- Log resolution at INFO only when the requested and resolved values differ.
+- Keep the existing index-cache behavior.
+
+## Implementation seams
+
+1. Add a pure resolver/selector module with unit tests for grammar,
+   precedence, ordering, host filtering, exact build matches, malformed input,
+   and no-match behavior.
+2. Integrate resolution into `build_installrecipe` for stable version specs.
+3. Ensure recipe construction, atomic recovery, package download paths, and
+   post-install linking use the concrete effective spec.
+4. Retain the original selector in recipe metadata without creating selector
+   directories or persistent selector state.
+5. Update install help/user-facing documentation and snapshots as needed.
+
+## Explicitly deferred
+
+Partial selectors in `pin`, `default`, `run`, shim lookup, `update`, or `list`;
+selector aliases; persistent selector metadata; nightly selector ranges; and
+general semver range support.
+
+See ADR `.agents/adr/0003-incomplete-stable-version-selectors.md` and the
+glossary entries in `CONTEXT.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,8 +9,14 @@ A named, self-contained installation of the MoonBit compiler and its components,
 _Avoid_: Install, build, distribution
 
 **Toolchain spec**:
-The identifier used to select a toolchain: `latest`, `nightly`, `bleeding`, or a specific version (e.g. `v1.0.0` or `nightly-2025-01-01`).
+The identifier used to select a toolchain: `latest`, `nightly`, `bleeding`, or a specific version (e.g. `1.0.0` or `nightly-2025-01-01`).
 _Avoid_: Channel, tag, release
+
+**Version selector**:
+A numeric stable-version input accepted by the install command. It may contain one, two, or three dot-separated components (for example, `0`, `0.10`, or `0.10.1`). A selector chooses a concrete stable release; it is not itself an installed toolchain identity.
+
+**Resolved release**:
+The concrete stable release selected from the ordered stable release index for a version selector. The resolved release, rather than the selector, is the toolchain's installation identity.
 
 **Atomic toolchain change**:
 An operation that replaces an installed toolchain such that the currently installed toolchain remains fully usable at every instant, even if the operation fails or the process is killed mid-way.

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -128,7 +128,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         );
     }
 
-    println!("Installing toolchain '{}'", spec);
+    println!("Installing toolchain '{}'", recipe.spec);
     populate_install(&recipe).await?;
     post_install(&recipe)?;
     link_dirs(&recipe)?;

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -111,7 +111,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         let recipe = staged.into_recipe(&spec);
         post_install(&recipe)?;
         link_dirs(&recipe)?;
-        atomic::acknowledge(&spec);
+        atomic::acknowledge(&recipe.spec);
         return Ok(());
     }
 
@@ -132,7 +132,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     populate_install(&recipe).await?;
     post_install(&recipe)?;
     link_dirs(&recipe)?;
-    atomic::acknowledge(&spec);
+    atomic::acknowledge(&recipe.spec);
 
     println!(
         "{}Installed toolchain version '{}'",

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -120,6 +120,14 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         std::process::exit(1);
     });
 
+    if recipe.requested_spec != recipe.spec {
+        tracing::info!(
+            requested = %recipe.requested_spec,
+            resolved = %recipe.spec,
+            "resolved stable version selector"
+        );
+    }
+
     println!("Installing toolchain '{}'", spec);
     populate_install(&recipe).await?;
     post_install(&recipe)?;
@@ -129,7 +137,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     println!(
         "{}Installed toolchain version '{}'",
         console::style(console::Emoji("✔ ", "")).green(),
-        spec
+        recipe.spec
     );
     println!(
         "Make sure '{}' is added to your PATH",

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -28,8 +28,9 @@ async fn update_toolchain(path: &mut PathBuf, spec: &ToolchainSpec) -> miette::R
     // resolution, so an interrupted update never leaves it without its
     // post-install steps; the pending marker is acknowledged once done.
     if let Some(staged) = atomic::recover(spec)? {
-        post_install(&staged.into_recipe(spec))?;
-        atomic::acknowledge(spec);
+        let recipe = staged.into_recipe(spec);
+        post_install(&recipe)?;
+        atomic::acknowledge(&recipe.spec);
     }
 
     let name = spec.as_str();

--- a/src/toolchain/atomic.rs
+++ b/src/toolchain/atomic.rs
@@ -73,6 +73,7 @@ impl StagedRelease {
     pub fn into_recipe(self, spec: &ToolchainSpec) -> InstallRecipe {
         InstallRecipe {
             spec: spec.clone(),
+            requested_spec: spec.clone(),
             release: Release {
                 version: self.version,
                 layout_version1: None,

--- a/src/toolchain/atomic.rs
+++ b/src/toolchain/atomic.rs
@@ -71,9 +71,17 @@ impl StagedRelease {
     /// post-install steps (shims, core library bundle, directory links)
     /// without resolving a fresh release from the network.
     pub fn into_recipe(self, spec: &ToolchainSpec) -> InstallRecipe {
+        let requested_spec = spec.clone();
+        let effective_spec = match spec {
+            ToolchainSpec::Version(value) if super::version::is_stable_selector(value) => {
+                ToolchainSpec::Version(self.version.clone())
+            }
+            _ => requested_spec.clone(),
+        };
+
         InstallRecipe {
-            spec: spec.clone(),
-            requested_spec: spec.clone(),
+            spec: effective_spec,
+            requested_spec,
             release: Release {
                 version: self.version,
                 layout_version1: None,

--- a/src/toolchain/index.rs
+++ b/src/toolchain/index.rs
@@ -10,13 +10,15 @@ use crate::dist_server::schema::{
 };
 use crate::utils::{build_dist_server_api, build_http_client_with_retry, url_to_reader};
 
-use super::ToolchainSpec;
+use super::{ToolchainSpec, version};
 
 /// The install recipe for performing a toolchain installation
 #[derive(Debug)]
 pub struct InstallRecipe {
-    /// The requested toolchain spec
+    /// The concrete toolchain spec used for installation and filesystem identity
     pub spec: ToolchainSpec,
+    /// The original user-requested spec, retained for diagnostics.
+    pub requested_spec: ToolchainSpec,
     /// The release information
     pub release: Release,
     /// The components to install
@@ -275,6 +277,9 @@ pub async fn build_installrecipe(spec: &ToolchainSpec) -> miette::Result<Option<
         ToolchainSpec::Bleeding | ToolchainSpec::Latest | ToolchainSpec::Nightly => {
             releases.next_back().cloned().or(None)
         }
+        ToolchainSpec::Version(s) if !s.starts_with("nightly") => {
+            version::resolve_stable_selector(s, releases).cloned()
+        }
         ToolchainSpec::Version(s) => {
             let is_nightly = s.starts_with("nightly");
 
@@ -313,8 +318,15 @@ pub async fn build_installrecipe(spec: &ToolchainSpec) -> miette::Result<Option<
         .await?
         .components()
         .to_vec();
+    let effective_spec = match spec {
+        ToolchainSpec::Version(s) if version::is_stable_selector(s) => {
+            ToolchainSpec::Version(release.version.clone())
+        }
+        _ => spec.clone(),
+    };
     let recipe = InstallRecipe {
-        spec: spec.clone(),
+        spec: effective_spec,
+        requested_spec: spec.clone(),
         release,
         components,
     };

--- a/src/toolchain/index.rs
+++ b/src/toolchain/index.rs
@@ -15,7 +15,9 @@ use super::{ToolchainSpec, version};
 /// The install recipe for performing a toolchain installation
 #[derive(Debug)]
 pub struct InstallRecipe {
-    /// The concrete toolchain spec used for installation and filesystem identity
+    /// The effective toolchain spec used for installation and filesystem identity.
+    ///
+    /// This may be a channel name (`latest`, `nightly`, `bleeding`) or a concrete version.
     pub spec: ToolchainSpec,
     /// The original user-requested spec, retained for diagnostics.
     pub requested_spec: ToolchainSpec,

--- a/src/toolchain/mod.rs
+++ b/src/toolchain/mod.rs
@@ -7,6 +7,7 @@ pub mod atomic;
 pub mod index;
 pub mod package;
 pub mod resolve;
+pub mod version;
 
 /// Install specification for a toolchain
 ///

--- a/src/toolchain/version.rs
+++ b/src/toolchain/version.rs
@@ -1,0 +1,110 @@
+use crate::dist_server::schema::Release;
+
+/// Whether a version is a numeric stable selector rather than a concrete
+/// build-qualified version.
+pub fn is_stable_selector(value: &str) -> bool {
+    !value.contains('+') && {
+        let parts = value.split('.').collect::<Vec<_>>();
+        (1..=3).contains(&parts.len())
+            && parts
+                .iter()
+                .all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit()))
+    }
+}
+
+/// Resolve a numeric stable-version selector against an oldest-first release list.
+pub fn resolve_stable_selector<'a>(
+    selector: &str,
+    mut releases: impl Iterator<Item = &'a Release>,
+) -> Option<&'a Release> {
+    if selector.contains('+') {
+        return releases.find(|release| release.version == selector);
+    }
+    if !is_stable_selector(selector) {
+        return None;
+    }
+    let parts = selector.split('.').collect::<Vec<_>>();
+
+    let matching = releases
+        .filter(|release| {
+            release
+                .version
+                .split('+')
+                .next()
+                .map(|base| {
+                    base.split('.').take(parts.len()).eq(parts.iter().copied())
+                        && base.split('.').count() >= parts.len()
+                })
+                .unwrap_or(false)
+        })
+        .collect::<Vec<_>>();
+
+    if parts.len() == 3 {
+        matching
+            .iter()
+            .copied()
+            .find(|release| release.version == selector)
+            .or_else(|| {
+                matching
+                    .into_iter()
+                    .rev()
+                    .find(|release| release.version.contains('+'))
+            })
+    } else {
+        matching.into_iter().next_back()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn releases(values: &[&str]) -> Vec<Release> {
+        values
+            .iter()
+            .map(|version| Release {
+                version: (*version).into(),
+                layout_version1: None,
+                bundle_source_dir: None,
+                date: None,
+                targets: None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn resolves_prefixes_and_three_part_precedence() {
+        let releases = releases(&["0.9.0", "0.10.0+old", "0.10.1+build", "0.10.1"]);
+        assert_eq!(
+            resolve_stable_selector("0", releases.iter())
+                .unwrap()
+                .version,
+            "0.10.1"
+        );
+        assert_eq!(
+            resolve_stable_selector("0.10", releases.iter())
+                .unwrap()
+                .version,
+            "0.10.1"
+        );
+        assert_eq!(
+            resolve_stable_selector("0.10.1", releases.iter())
+                .unwrap()
+                .version,
+            "0.10.1"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_last_build_and_rejects_malformed_selectors() {
+        let releases = releases(&["0.10.1+old", "0.10.1+new"]);
+        assert_eq!(
+            resolve_stable_selector("0.10.1", releases.iter())
+                .unwrap()
+                .version,
+            "0.10.1+new"
+        );
+        assert!(resolve_stable_selector("v0.10", releases.iter()).is_none());
+        assert!(resolve_stable_selector("0.10.1.2", releases.iter()).is_none());
+    }
+}

--- a/tests/integration/atomic.rs
+++ b/tests/integration/atomic.rs
@@ -68,6 +68,23 @@ fn test_recover_promotes_complete_staging() {
 }
 
 #[test]
+fn test_recovery_recipe_uses_concrete_spec_for_stable_selector() {
+    let staged = atomic::StagedRelease {
+        version: "0.10.1+build".to_string(),
+        ..Default::default()
+    };
+    let requested = ToolchainSpec::Version("0.10".to_string());
+
+    let recipe = staged.into_recipe(&requested);
+
+    assert_eq!(
+        recipe.spec,
+        ToolchainSpec::Version("0.10.1+build".to_string())
+    );
+    assert_eq!(recipe.requested_spec, requested);
+}
+
+#[test]
 fn test_recover_does_not_promote_incomplete_staging() {
     let tempdir = assert_fs::TempDir::new().expect("should create tempdir");
     let moonup_home = tempdir.path().join(".moonup");

--- a/tests/integration/atomic.rs
+++ b/tests/integration/atomic.rs
@@ -224,6 +224,7 @@ fn test_staged_matches_requires_same_release() {
 
             let recipe = |version: &str| InstallRecipe {
                 spec: spec.clone(),
+                requested_spec: spec.clone(),
                 release: Release {
                     version: version.to_string(),
                     layout_version1: None,

--- a/tests/integration/package.rs
+++ b/tests/integration/package.rs
@@ -24,6 +24,7 @@ fn test_populate_install_redownloads_invalid_cache() {
 
     let recipe = InstallRecipe {
         spec: ToolchainSpec::Version(version.to_string()),
+        requested_spec: ToolchainSpec::Version(version.to_string()),
         release: Release {
             version: version.to_string(),
             layout_version1: None,


### PR DESCRIPTION
An improved design to address #189 , replace and close #190

This would be a BRAKING CHANGE, as it will surprise users that `0.10.0` can now be resolved to a concrete release.