### PR TITLE
feat(toolchain): list installed toolchains in release order

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,6 +27,10 @@ _Avoid_: Install in place
 A wrapper executable in `MOON_HOME/bin/` (and `bin/internal/`) that forwards a toolchain command (e.g. `moon`) to the active toolchain's real binary via moonup. It is a copy of the `moonup-shim` binary named after the toolchain command.
 _Avoid_: Launcher, proxy
 
+**Release order**:
+The order in which installed toolchains are listed: versioned installs first, grouped by channel and ordered oldest-to-newest by release date, then the floating channel aliases in `bleeding` → `nightly` → `latest` order.
+_Avoid_: Alphabetical order, install name order
+
 **Retire**:
 Moving a replaced executable into the hidden `MOON_HOME/bin/.trash/` directory under a unique name so the live name is freed immediately, deleting it best-effort once any process holding it has exited. On Windows a running executable can be renamed but not deleted, which is why retirement precedes deletion.
 _Avoid_: Delete in place

--- a/src/toolchain/mod.rs
+++ b/src/toolchain/mod.rs
@@ -1,7 +1,8 @@
 use miette::IntoDiagnostic;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use crate::dist_server::schema::ChannelName;
+use crate::dist_server::schema::{ChannelIndex, ChannelName};
 
 pub mod atomic;
 pub mod index;
@@ -64,51 +65,6 @@ impl ToolchainSpec {
             ToolchainSpec::Bleeding => "bleeding",
             ToolchainSpec::Version(v) => v.as_str(),
         }
-    }
-}
-
-impl Ord for ToolchainSpec {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        match (self, other) {
-            // latest
-            (ToolchainSpec::Latest, ToolchainSpec::Latest) => std::cmp::Ordering::Equal,
-            (ToolchainSpec::Latest, ToolchainSpec::Nightly) => std::cmp::Ordering::Less,
-            (ToolchainSpec::Latest, ToolchainSpec::Bleeding) => std::cmp::Ordering::Less,
-            (ToolchainSpec::Latest, ToolchainSpec::Version(s)) => {
-                if s.starts_with("nightly") {
-                    std::cmp::Ordering::Less
-                } else {
-                    std::cmp::Ordering::Greater
-                }
-            }
-            // nightly
-            (ToolchainSpec::Nightly, ToolchainSpec::Nightly) => std::cmp::Ordering::Equal,
-            (ToolchainSpec::Nightly, ToolchainSpec::Latest) => std::cmp::Ordering::Greater,
-            (ToolchainSpec::Nightly, ToolchainSpec::Bleeding) => std::cmp::Ordering::Less,
-            (ToolchainSpec::Nightly, ToolchainSpec::Version(_)) => std::cmp::Ordering::Greater,
-            // bleeding
-            (ToolchainSpec::Bleeding, ToolchainSpec::Bleeding) => std::cmp::Ordering::Equal,
-            (ToolchainSpec::Bleeding, ToolchainSpec::Latest) => std::cmp::Ordering::Greater,
-            (ToolchainSpec::Bleeding, ToolchainSpec::Nightly) => std::cmp::Ordering::Greater,
-            (ToolchainSpec::Bleeding, ToolchainSpec::Version(_)) => std::cmp::Ordering::Greater,
-            // version
-            (ToolchainSpec::Version(a), ToolchainSpec::Version(b)) => a.cmp(b),
-            (ToolchainSpec::Version(s), ToolchainSpec::Latest) => {
-                if s.starts_with("nightly") {
-                    std::cmp::Ordering::Greater
-                } else {
-                    std::cmp::Ordering::Less
-                }
-            }
-            (ToolchainSpec::Version(_), ToolchainSpec::Nightly) => std::cmp::Ordering::Less,
-            (ToolchainSpec::Version(_), ToolchainSpec::Bleeding) => std::cmp::Ordering::Less,
-        }
-    }
-}
-
-impl PartialOrd for ToolchainSpec {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
     }
 }
 
@@ -211,10 +167,97 @@ pub fn installed_toolchains() -> miette::Result<Vec<InstalledToolchain>> {
                 .filter(|e| !e.file_name().to_string_lossy().starts_with('.'))
                 .filter_map(|e| InstalledToolchain::from_path(&e.path()).ok())
                 .collect::<Vec<_>>();
-            t.sort_by_key(|t| t.name.clone());
+
+            // List in release order: versioned installs grouped by channel
+            // (nightly builds by build date, latest releases by their position
+            // in the cached `latest` channel index), followed by the channel
+            // aliases `bleeding` < `nightly` < `latest`.
+            let latest_positions = read_latest_channel_positions(&t);
+            t.sort_by(|a, b| {
+                release_order(&a.name, &latest_positions)
+                    .cmp(&release_order(&b.name, &latest_positions))
+            });
             t
         }
     };
 
     Ok(toolchains)
+}
+
+/// The release order of an installed toolchain, oldest first.
+///
+/// Versioned installs precede the floating channel aliases, grouped by channel
+/// and ordered by release date. The aliases sort `bleeding` < `nightly` <
+/// `latest`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum ReleaseOrder {
+    /// A versioned nightly install, ordered by its build date (YYYY-MM-DD)
+    Nightly(String),
+    /// A versioned latest install, ordered by its position in the cached
+    /// `latest` channel index (a release absent from the index is older and
+    /// sorts first), then numerically by version
+    Latest(Option<usize>, NumericVersion),
+    /// A floating channel alias: `bleeding` < `nightly` < `latest`
+    Channel(u8),
+}
+
+/// A version number compared component-wise, so `0.10.6` orders after `0.9.0`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct NumericVersion(Vec<u64>);
+
+impl NumericVersion {
+    fn parse(version: &str) -> Self {
+        // ignore the `+build` metadata suffix (e.g. `0.10.6+80dc50f24`)
+        let core = version.split('+').next().unwrap_or(version);
+        let parts = core
+            .split('.')
+            .map(|p| p.parse::<u64>().unwrap_or(0))
+            .collect();
+        NumericVersion(parts)
+    }
+}
+
+/// Derive the [`ReleaseOrder`] sort key for an installed toolchain.
+fn release_order(spec: &ToolchainSpec, latest_positions: &HashMap<String, usize>) -> ReleaseOrder {
+    match spec {
+        ToolchainSpec::Bleeding => ReleaseOrder::Channel(0),
+        ToolchainSpec::Nightly => ReleaseOrder::Channel(1),
+        ToolchainSpec::Latest => ReleaseOrder::Channel(2),
+        ToolchainSpec::Version(v) if v.starts_with("nightly") => {
+            ReleaseOrder::Nightly(v.trim_start_matches("nightly-").to_owned())
+        }
+        ToolchainSpec::Version(v) => {
+            ReleaseOrder::Latest(latest_positions.get(v).copied(), NumericVersion::parse(v))
+        }
+    }
+}
+
+/// Positions of latest releases in the cached `latest` channel index, used to
+/// order latest-channel installs. Offline and best-effort: on any read or
+/// parse error the installs fall back to numeric version ordering.
+fn read_latest_channel_positions(installs: &[InstalledToolchain]) -> HashMap<String, usize> {
+    let has_latest = installs.iter().any(|t| match &t.name {
+        ToolchainSpec::Version(v) => !v.starts_with("nightly"),
+        _ => false,
+    });
+    if !has_latest {
+        return HashMap::new();
+    }
+
+    let path = crate::moonup_home()
+        .join("downloads")
+        .join("channel-latest.json");
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return HashMap::new();
+    };
+    let Ok(index) = serde_json::from_str::<ChannelIndex>(&content) else {
+        return HashMap::new();
+    };
+
+    index
+        .releases()
+        .iter()
+        .enumerate()
+        .map(|(i, r)| (r.version.clone(), i))
+        .collect()
 }

--- a/src/toolchain/mod.rs
+++ b/src/toolchain/mod.rs
@@ -191,8 +191,8 @@ enum ReleaseOrder {
     /// A versioned nightly install, ordered by its build date (YYYY-MM-DD)
     Nightly(String),
     /// A versioned latest install, ordered by its position in the cached
-    /// `latest` channel index (a release absent from the index is older and
-    /// sorts first), then numerically by version
+    /// `latest` channel index. A release absent from the index triggers
+    /// a fallback to numeric version ordering for the whole group
     Latest(Option<usize>, NumericVersion),
     /// A floating channel alias: `bleeding` < `nightly` < `latest`
     Channel(u8),

--- a/src/toolchain/mod.rs
+++ b/src/toolchain/mod.rs
@@ -173,10 +173,7 @@ pub fn installed_toolchains() -> miette::Result<Vec<InstalledToolchain>> {
             // in the cached `latest` channel index), followed by the channel
             // aliases `bleeding` < `nightly` < `latest`.
             let latest_positions = read_latest_channel_positions(&t);
-            t.sort_by(|a, b| {
-                release_order(&a.name, &latest_positions)
-                    .cmp(&release_order(&b.name, &latest_positions))
-            });
+            t.sort_by_key(|it| release_order(&it.name, &latest_positions));
             t
         }
     };

--- a/src/toolchain/mod.rs
+++ b/src/toolchain/mod.rs
@@ -236,11 +236,14 @@ fn release_order(spec: &ToolchainSpec, latest_positions: &HashMap<String, usize>
 /// order latest-channel installs. Offline and best-effort: on any read or
 /// parse error the installs fall back to numeric version ordering.
 fn read_latest_channel_positions(installs: &[InstalledToolchain]) -> HashMap<String, usize> {
-    let has_latest = installs.iter().any(|t| match &t.name {
-        ToolchainSpec::Version(v) => !v.starts_with("nightly"),
-        _ => false,
-    });
-    if !has_latest {
+    let latest_versions = installs
+        .iter()
+        .filter_map(|t| match &t.name {
+            ToolchainSpec::Version(v) if !v.starts_with("nightly") => Some(v.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    if latest_versions.is_empty() {
         return HashMap::new();
     }
 
@@ -254,10 +257,20 @@ fn read_latest_channel_positions(installs: &[InstalledToolchain]) -> HashMap<Str
         return HashMap::new();
     };
 
-    index
+    let positions = index
         .releases()
         .iter()
         .enumerate()
         .map(|(i, r)| (r.version.clone(), i))
-        .collect()
+        .collect::<HashMap<_, _>>();
+
+    // A stale cache that lacks one of the installed releases would otherwise
+    // sort that release (as `None`) below older releases that are present in
+    // the index, breaking oldest-to-newest order. If the cache is incomplete,
+    // fall back to pure numeric version ordering for the whole group.
+    if latest_versions.iter().any(|v| !positions.contains_key(v)) {
+        return HashMap::new();
+    }
+
+    positions
 }

--- a/tests/integration/atomic.rs
+++ b/tests/integration/atomic.rs
@@ -271,6 +271,42 @@ fn test_installed_toolchains_excludes_staging() {
 }
 
 #[test]
+fn test_installed_toolchains_stale_latest_cache_falls_back_to_numeric() {
+    let tempdir = assert_fs::TempDir::new().expect("should create tempdir");
+    let moonup_home = tempdir.path().join(".moonup");
+
+    temp_env::with_var(
+        constant::ENVNAME_MOONUP_HOME,
+        Some(moonup_home.as_os_str()),
+        || {
+            // A stale cache that no longer lists the installed `0.11.0` must not
+            // sort it below `0.10.0` (which the cache does list); the whole
+            // latest group falls back to numeric version ordering.
+            let toolchains_dir = moonup_home.join("toolchains");
+            for v in ["0.10.0", "0.11.0"] {
+                std::fs::create_dir_all(toolchains_dir.join(v))
+                    .expect("should create toolchain dir");
+            }
+
+            let downloads_dir = moonup_home.join("downloads");
+            std::fs::create_dir_all(&downloads_dir).expect("should create downloads dir");
+            std::fs::write(
+                downloads_dir.join("channel-latest.json"),
+                r#"{ "version": 3, "lastModified": "STALE", "releases": [ { "version": "0.10.0", "targets": ["aarch64-apple-darwin"] } ] }"#,
+            )
+            .expect("should write stale latest cache");
+
+            let installed = installed_toolchains().expect("should list installed toolchains");
+            let names = installed
+                .iter()
+                .map(|t| t.name.to_string())
+                .collect::<Vec<_>>();
+            assert_eq!(names, vec!["0.10.0", "0.11.0"]);
+        },
+    );
+}
+
+#[test]
 fn test_swap_sweeps_deletable_stale_retired() {
     let tempdir = assert_fs::TempDir::new().expect("should create tempdir");
     let moonup_home = tempdir.path().join(".moonup");


### PR DESCRIPTION
before:

```
Installed toolchains:
  0.10.3+16975d007
  0.10.6+80dc50f24
  0.6.22
  0.6.24+012953835
  0.6.29+9037370fc
  0.9.2+bbe2b338f
  0.9.3+08f337e2c
  latest (0.10.6+80dc50f24)
  nightly-2026-08-08
  nightly (2026-07-28)
```

after

```
Installed toolchains:
  nightly-2026-08-08
  0.6.22
  0.6.24+012953835
  0.6.29+9037370fc
  0.9.2+bbe2b338f
  0.9.3+08f337e2c
  0.10.3+16975d007
  0.10.6+80dc50f24
  nightly (2026-07-28)
  latest (0.10.6+80dc50f24)
```